### PR TITLE
story(VENLY-5070) - segwit support for Litecoin - fix params

### DIFF
--- a/core/src/main/java/org/litecoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/litecoinj/params/MainNetParams.java
@@ -45,7 +45,7 @@ public class MainNetParams extends LitecoinNetworkParams {
 
         port = 9333;
         packetMagic = 0xfbc0b6db;
-        dumpedPrivateKeyHeader = 128;
+        dumpedPrivateKeyHeader = 176;
         spendableCoinbaseDepth = 100;
         bip32HeaderP2PKHpub = 0x0488b21e; // The 4 byte header that serializes in base58 to "xpub".
         bip32HeaderP2PKHpriv = 0x0488ade4; // The 4 byte header that serializes in base58 to "xprv"


### PR DESCRIPTION
- fix `getVersion()` to return also the second type of p2sh header (M-addresses)
- fix `addressHeader` from `0` to `48` (adapted to litecoin mainnet network)
- fix `dumpedPrivateKeyHeader` to `176` (adapted to litecoin mainnet network)